### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,5 +1,8 @@
 name: Unit Tests, Lint, and Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/adjstreams/twitch-user-notes/security/code-scanning/2](https://github.com/adjstreams/twitch-user-notes/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout` step requires `contents: read` to fetch the repository code.
- The `codecov/codecov-action` step may require `contents: read` to upload coverage reports, but it does not need write permissions.

We will set `contents: read` as the only permission for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
